### PR TITLE
Fix installation instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ XML documentation comments on MSDN. https://docs.microsoft.com/en-us/dotnet/csha
 ## Installation
 
 ```bash
-dotnet install tool -g loxsmoke.mddox
+dotnet tool install -g loxsmoke.mddox
 ```
 
 ## Uninstallation


### PR DESCRIPTION
This PR fixes the following installation instruction in README:

    dotnet install tool -g loxsmoke.mddox

that, when executed, results in the following error:

```
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET Core program, but dotnet-install does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```

`install` is a sub-command of `tool` and so much come after:

    dotnet tool install -g loxsmoke.mddox

With this fix, the result is a successful install:

```
You can invoke the tool using the following command: mddox
Tool 'loxsmoke.mddox' (version '0.2.0') was successfully installed.
```
