### PR TITLE
Don't document base type `System.ValueType`

### DIFF
--- a/src/DocumentationGenerator.cs
+++ b/src/DocumentationGenerator.cs
@@ -320,7 +320,9 @@ namespace MdDox
             Writer.WriteH1(TypeTitle(typeData.Type));
             Writer.WriteLine("Namespace: " + typeData.Type.Namespace);
 
-            if (typeData.Type.BaseType != null && typeData.Type.BaseType != typeof(Object))
+            if (typeData.Type.BaseType != null &&
+                typeData.Type.BaseType != typeof(Object) &&
+                typeData.Type.BaseType != typeof(ValueType))
             {
                 Writer.WriteLine("Base class: " + typeData.Type.BaseType.ToNameString(typeLinkConverter, true));
             }


### PR DESCRIPTION
Currently the type `System.ValueType` is documented as the base type of any documented `struct`. For a documented `class`, however, the base type `System.Object` is not documented. I think both cases should be handled the same way.

I'm not sure if the extended `if` condition aligns with your coding style. I'd be happy to change it if you have objections.