### PR TITLE
Remove special characters from anchor links

### DIFF
--- a/src/MarkdownWriters/BitbucketMarkdownWriter.cs
+++ b/src/MarkdownWriters/BitbucketMarkdownWriter.cs
@@ -108,7 +108,7 @@ namespace MdDox.MarkdownWriters
 
         public string HeadingLink(string anchorName, string text)
         {
-            return $"[{text}](#markdown-header-{anchorName.Replace(" ", "-").ToLower()})";
+            return $"[{text}](#{anchorName.ToLower().RegexReplace(@"[^a-z\d -]", "").Replace(" ", "-")})";
         }
         #endregion
 

--- a/src/MarkdownWriters/GithubMarkdownWriter.cs
+++ b/src/MarkdownWriters/GithubMarkdownWriter.cs
@@ -103,7 +103,7 @@ namespace MdDox.MarkdownWriters
         }
         public string HeadingLink(string anchorName, string text)
         {
-            return $"[{text}](#{anchorName.Replace(" ", "-").ToLower()})";
+            return $"[{text}](#{anchorName.ToLower().RegexReplace(@"[^a-z\d -]", "").Replace(" ", "-")})";
         }
         #endregion
 

--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.RegularExpressions;
+
+namespace MdDox
+{
+    internal static class StringExtensions
+    {
+        public static string RegexReplace(this string input, string pattern, string replacement)
+            => Regex.Replace(input, pattern, replacement);
+    }
+}


### PR DESCRIPTION
This fixes a bug where mddox generates broken anchor links for generic types in the type index.

## Example

For the type `OPPBuilder<TUserState, TTerm, TAfterString>` mddox generates the following markdown:

```markdown
[OPPBuilder\<TUserState, TTerm, TAfterString\> Class](#oppbuilder\<tuserstate,-tterm,-tafterstring\>-class)
```

The correct markdown it should generate is:

```markdown
[OPPBuilder\<TUserState, TTerm, TAfterString\> Class](#oppbuildertuserstate-tterm-tafterstring-class)
```

Unfortunately I can't prove it to you inside this PR, because anchor links are not supported here.

I assume the escaping logic is the same for BitBucket, so I adjusted both `MarkdownWriter`s.