### PR TITLE
Turn <para> tags into line breaks

### DIFF
--- a/src/DocumentationGenerator.cs
+++ b/src/DocumentationGenerator.cs
@@ -310,7 +310,7 @@ namespace MdDox
                     continue;
                 }
 
-                return text;
+                return RemoveParaTags(text);
             }
         }
 
@@ -340,6 +340,12 @@ namespace MdDox
             var url = $"https://docs.microsoft.com/{docLocale}/dotnet/api/{typeNameFragment}{urlParameters}";
             return url;
         }
+
+        static string RemoveParaTags(string text) => text?
+            .RegexReplace(@"\s*</para>\s*<para>\s*", "\r\n\r\n")
+            .RegexReplace(@"\s*<para>\s*", "\r\n\r\n")
+            .RegexReplace(@"\s*</para>\s*", "\r\n\r\n")
+            .Trim();
 
         /// <summary>
         /// Write table of contents. It is a three column table with each cell containing 

--- a/src/DocumentationGenerator.cs
+++ b/src/DocumentationGenerator.cs
@@ -453,13 +453,13 @@ namespace MdDox
             {
                 Writer.WriteH2("Constructors");
                 Writer.WriteTableTitle("Name", "Summary");
-                foreach (var prop in allMethods
+                foreach (var ctor in allMethods
                     .Where(m => m.Info is ConstructorInfo)
-                    .OrderBy(p => p.Info.GetParameters().Length))
+                    .OrderBy(m => m.Info.GetParameters().Length))
                 {
                     Writer.WriteTableRow(
-                        Writer.Bold(typeData.Type.ToNameString() + prop.Info.ToParametersString(typeLinkConverter, true)),
-                        prop.Comments.Summary);
+                        Writer.Bold(typeData.Type.ToNameString() + ctor.Info.ToParametersString(typeLinkConverter, true)),
+                        ProcessTags(ctor.Comments.Summary));
                 }
             }
 
@@ -469,14 +469,14 @@ namespace MdDox
                 Writer.WriteTableTitle("Name", "Returns", "Summary");
                 foreach (var method in allMethods
                     .Where(m => m.Info != null && !(m.Info is ConstructorInfo) && (m.Info is MethodInfo))
-                    .OrderBy(p => p.Info.Name)
-                    .ThenBy(p => p.Info.GetParameters().Length))
+                    .OrderBy(m => m.Info.Name)
+                    .ThenBy(m => m.Info.GetParameters().Length))
                 {
                     var methodInfo = method.Info as MethodInfo;
                     Writer.WriteTableRow(
                         Writer.Bold(methodInfo.Name + methodInfo.ToParametersString(typeLinkConverter, true)),
                         methodInfo.ToTypeNameString(typeLinkConverter, true),
-                        method.Comments.Summary);
+                        ProcessTags(method.Comments.Summary));
                 }
             }
 


### PR DESCRIPTION
This patch turns `<para>` tags into `\r\n` line breaks which mddox will turn into `<br>`s later.

It also adds processing of tags with `ProcessTags()` in some places where it has been forgotten. At least I think so. Please check if they were omitted on purpose instead.

That "parsing" logic is pretty basic, but should work for the most cases.

Those are the cases I tested manually:

```xml
<summary>
<para>
foo
</para>
<para>
bar
</para>
</summary>

<summary>
<para>foo</para>
<para>
bar
</para>
</summary>

<summary>
<para>
foo
</para>
</summary>

<summary>
<para>
foo
</para>
bar
</summary>

<summary>
<para>foo</para>
</summary>

<summary>
<para>foo</para><para>bar</para>
</summary>

<summary>
<para>foo</para>
</summary>

<summary>
<para>
foo
<para>
bar
</para>
</para>
</summary>
```

Here is a case I noticed that won't work perfectly:

```xml
<summary>
<para>
foo
<para>
bar
</para>
</para>
qux
</summary>
```

The resulting markdown would be:

```markdown
foo<br><br>
bar<br><br>
<br><br>
qux
```

As you can see there are too many breaks between `bar` and `qux`. I think this is something we could live with, considering that the input XML has an unusual structure to begin with.

A viable fix for this might be to ensure that all sequences of `\r\n` have a maximum length of two at the end of `RemoveParaTags()` using `RegexReplace("(\r\n){3,}", "\r\n\r\n")`. However, this will also remove any of such line breaks the user typed into the comments intentionally.