### PR TITLE
[Feature] Add Multi-language Support & Fix Heading Link Jump Not Working Problem

### DIFF
--- a/src/DocumentationGenerator.cs
+++ b/src/DocumentationGenerator.cs
@@ -411,6 +411,7 @@ namespace MdDox
         #region Simple formatted write functions
         public void WriteTypeTitle(Type type)
         {
+            WriteLine($"<a id=\"{type.ToNameString().ToLower()}-\"></a>");
             WriteBigTitle(TypeTitle(type));
 
             WriteLine("Namespace: ".GetLocalized() + type.Namespace);

--- a/src/DocumentationGenerator.cs
+++ b/src/DocumentationGenerator.cs
@@ -51,7 +51,6 @@ namespace MdDox
             TypeList = typeList;
             Options = options;
             Markdown = writer;
-
             typeLinkConverter = (type, _) => TypeNameWithLinks(type, options.MsdnLinks, options.MsdnView);
         }
 
@@ -61,7 +60,7 @@ namespace MdDox
             OutputText.Clear();
             WriteDocumentTitle(Options.DocumentTitle);
             WritedDateLine();
-            WriteTypeIndex(Options.TypeIndexTitle, Options.TypeIndexColumnCount);
+            WriteTypeIndex("All types".GetLocalized(), Options.TypeIndexColumnCount);
             foreach (var typeData in TypeList.TypesToDocument)
             {
                 WriteTypeDocumentation(typeData);
@@ -134,8 +133,9 @@ namespace MdDox
 
             if (enumComments.ValueComments.Count > 0)
             {
-                WriteTitle("Values");
-                WriteTableTitle("Name", "Summary");
+
+                WriteTitle("Values".GetLocalized());
+                WriteTableTitle("Name".GetLocalized(), "Summary".GetLocalized());
                 foreach (var prop in enumComments.ValueComments)
                 {
                     WriteTableRow(Markdown.Bold(prop.Name), ProcessTags(prop.Summary));
@@ -156,7 +156,7 @@ namespace MdDox
                 typeData.Type.BaseType != typeof(Object) &&
                 typeData.Type.BaseType != typeof(ValueType))
             {
-                WriteLine("Base class: " + typeData.Type.BaseType.ToNameString(typeLinkConverter, true));
+                WriteLine("Base class: ".GetLocalized() + typeData.Type.BaseType.ToNameString(typeLinkConverter, true));
             }
 
             var typeComments = Reader.GetTypeComments(typeData.Type);
@@ -171,8 +171,9 @@ namespace MdDox
             var allFields = Reader.Comments(typeData.Fields).ToList();
             if (allProperties.Count > 0)
             {
-                WriteTitle("Properties");
-                WriteTableTitle("Name", "Type", "Summary");
+
+                WriteTitle("Properties".GetLocalized());
+                WriteTableTitle("Name".GetLocalized(), "Type".GetLocalized(), "Summary".GetLocalized());
                 foreach (var (Info, Comments) in allProperties)
                 {
                     WriteTableRow(
@@ -184,8 +185,8 @@ namespace MdDox
 
             if (allConstructors.Count > 0)
             {
-                WriteTitle("Constructors");
-                WriteTableTitle("Name", "Summary");
+                WriteTitle("Constructors".GetLocalized());
+                WriteTableTitle("Name".GetLocalized(), "Summary".GetLocalized());
                 foreach (var (Info, Comments) in allConstructors.OrderBy(m => m.Info.GetParameters().Length))
                 {
                     var heading = typeData.Type.ToNameString() + Info.ToParametersString(typeLinkConverter, true);
@@ -196,8 +197,8 @@ namespace MdDox
 
             if (allMethods.Count > 0)
             {
-                WriteTitle("Methods");
-                WriteTableTitle("Name", "Returns", "Summary");
+                WriteTitle("Methods".GetLocalized());
+                WriteTableTitle("Name".GetLocalized(), "Returns".GetLocalized(), "Summary".GetLocalized());
                 foreach (var (Info, Comments) in allMethods
                     .OrderBy(m => m.Info.Name)
                     .ThenBy(m => m.Info.GetParameters().Length))
@@ -216,8 +217,9 @@ namespace MdDox
 
             if (allFields.Count > 0)
             {
-                WriteTitle("Fields");
-                WriteTableTitle("Name", "Type", "Summary");
+
+                WriteTitle("Fields".GetLocalized());
+                WriteTableTitle("Name".GetLocalized(), "Type".GetLocalized(), "Summary".GetLocalized());
                 foreach (var (Info, Comments) in allFields)
                 {
                     WriteTableRow(
@@ -231,7 +233,7 @@ namespace MdDox
             {
                 if (allConstructors.Count > 0)
                 {
-                    WriteTitle("Constructors");
+                    WriteTitle("Constructors".GetLocalized());
                     foreach (var (info, comments) in allConstructors
                         .OrderBy(m => m.Info.GetParameters().Length))
                     {
@@ -240,7 +242,7 @@ namespace MdDox
                 }
                 if (allMethods.Count > 0)
                 {
-                    WriteTitle("Methods");
+                    WriteTitle("Methods".GetLocalized());
                     foreach (var (info, comments) in allMethods
                         .OrderBy(m => m.Info.Name)
                         .ThenBy(m => m.Info.GetParameters().Length))
@@ -259,7 +261,8 @@ namespace MdDox
             {
                 var parameters = info.GetParameters();
                 var i = 0;
-                WriteTableTitle("Parameter", "Type", "Description");
+                
+                WriteTableTitle("Parameter".GetLocalized(), "Type".GetLocalized(), "Description".GetLocalized());
                 foreach (var (paramName, text) in comments.Parameters)
                 {
                     WriteTableRow(paramName,
@@ -271,7 +274,7 @@ namespace MdDox
 
             if (info is MethodInfo methodInfo && methodInfo.ReturnType != typeof(void))
             {
-                WriteSmallTitle("Returns");
+                WriteSmallTitle("Returns".GetLocalized());
                 WriteLine(methodInfo.ToTypeNameString(typeLinkConverter, true));
                 WriteSummary(comments.Returns);
             }
@@ -394,10 +397,11 @@ namespace MdDox
         static string TypeTitle(Type type)
         {
             string complement;
-            if (type.IsEnum) complement = " Enum";
-            else if (type.IsInterface) complement = " Interface";
-            else if (type.IsValueType) complement = " Struct";
-            else complement = " Class";
+            
+            if (type.IsEnum) complement = " Enum".GetLocalized();
+            else if (type.IsInterface) complement = " Interface".GetLocalized();
+            else if (type.IsValueType) complement = " Struct".GetLocalized();
+            else complement = " Class".GetLocalized();
 
             return type.ToNameString() + complement;
         }
@@ -408,7 +412,8 @@ namespace MdDox
         public void WriteTypeTitle(Type type)
         {
             WriteBigTitle(TypeTitle(type));
-            WriteLine("Namespace: " + type.Namespace);
+
+            WriteLine("Namespace: ".GetLocalized() + type.Namespace);
         }
 
         public void WriteSummary(string summary)
@@ -420,14 +425,14 @@ namespace MdDox
         {
             if (example.IsNullOrEmpty()) return;
 
-            WriteTitle("Examples");
+            WriteTitle("Examples".GetLocalized());
             WriteLine(ProcessTags(example));
         }
         public void WriteRemarks(string remarks)
         {
             if (remarks.IsNullOrEmpty()) return;
 
-            WriteTitle("Remarks");
+            WriteTitle("Remarks".GetLocalized());
             WriteLine(ProcessTags(remarks));
         }
         #endregion

--- a/src/DocumentationGeneratorOptions.cs
+++ b/src/DocumentationGeneratorOptions.cs
@@ -11,7 +11,6 @@ namespace MdDox
         public bool ShowDocumentDateTime { get; set; }
         public bool MsdnLinks { get; set; }
         public string MsdnView { get; set; }
-        public string TypeIndexTitle { get; set; } = "All types";
         public int TypeIndexColumnCount { get; set; } = 3;
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -177,7 +177,7 @@ namespace MdDox
             if (format == null && assembly == null) return null;
             var assemblyName = assembly == null ? "" : Path.GetFileName(assembly.ManifestModule.Name);
             var version = assembly == null ? "" : ("v." + assembly.GetName().Version);
-            if (format == null) format = "{assembly} {version} API documentation";
+            if (format == null) format = "{assembly} {version} " + "API documentation".GetLocalized();
             return format.Replace("{assembly}", assemblyName).Replace("{version}", version);
         }
 

--- a/src/Resources/Resources.en-US.resx
+++ b/src/Resources/Resources.en-US.resx
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Values" xml:space="preserve">
+    <value>Values</value>
+    <comment/>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Name</value>
+    <comment/>
+  </data>
+  <data name="Summary" xml:space="preserve">
+    <value>Summary</value>
+    <comment/>
+  </data>
+  <data name="Base class: " xml:space="preserve">
+    <value>Base class: </value>
+    <comment/>
+  </data>
+  <data name="Properties" xml:space="preserve">
+    <value>Properties</value>
+    <comment/>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Type</value>
+    <comment/>
+  </data>
+  <data name="Constructors" xml:space="preserve">
+    <value>Constructors</value>
+    <comment/>
+  </data>
+  <data name="Methods" xml:space="preserve">
+    <value>Methods</value>
+    <comment/>
+  </data>
+  <data name="Returns" xml:space="preserve">
+    <value>Returns</value>
+    <comment/>
+  </data>
+  <data name="Fields" xml:space="preserve">
+    <value>Fields</value>
+    <comment/>
+  </data>
+  <data name="Parameter" xml:space="preserve">
+    <value>Parameter</value>
+    <comment/>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Description</value>
+    <comment/>
+  </data>
+  <data name="Namespace: " xml:space="preserve">
+    <value>Namespace: </value>
+    <comment/>
+  </data>
+  <data name="Examples" xml:space="preserve">
+    <value>Examples</value>
+    <comment/>
+  </data>
+  <data name="Remarks" xml:space="preserve">
+    <value>Remarks</value>
+    <comment/>
+  </data>
+  <data name="All types" xml:space="preserve">
+    <value>All types</value>
+    <comment/>
+  </data>
+  <data name="API documentation" xml:space="preserve">
+    <value>API documentation</value>
+    <comment/>
+  </data>
+  <data name=" Enum" xml:space="preserve">
+    <value> Enum</value>
+    <comment/>
+  </data>
+  <data name=" Interface" xml:space="preserve">
+    <value> Interface</value>
+    <comment/>
+  </data>
+  <data name=" Struct" xml:space="preserve">
+    <value> Struct</value>
+    <comment/>
+  </data>
+  <data name=" Class" xml:space="preserve">
+    <value> Class</value>
+    <comment/>
+  </data>
+</root>

--- a/src/Resources/Resources.zh-CN.resx
+++ b/src/Resources/Resources.zh-CN.resx
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Values" xml:space="preserve">
+    <value>值</value>
+    <comment/>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>名称</value>
+    <comment/>
+  </data>
+  <data name="Summary" xml:space="preserve">
+    <value>摘要</value>
+    <comment/>
+  </data>
+  <data name="Base class: " xml:space="preserve">
+    <value>基类：</value>
+    <comment/>
+  </data>
+  <data name="Properties" xml:space="preserve">
+    <value>属性</value>
+    <comment/>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>类型</value>
+    <comment/>
+  </data>
+  <data name="Constructors" xml:space="preserve">
+    <value>构造函数</value>
+    <comment/>
+  </data>
+  <data name="Methods" xml:space="preserve">
+    <value>方法</value>
+    <comment/>
+  </data>
+  <data name="Returns" xml:space="preserve">
+    <value>返回</value>
+    <comment/>
+  </data>
+  <data name="Fields" xml:space="preserve">
+    <value>字段</value>
+    <comment/>
+  </data>
+  <data name="Parameter" xml:space="preserve">
+    <value>参数</value>
+    <comment/>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>描述</value>
+    <comment/>
+  </data>
+  <data name="Namespace: " xml:space="preserve">
+    <value>命名空间：</value>
+    <comment/>
+  </data>
+  <data name="Examples" xml:space="preserve">
+    <value>示例</value>
+    <comment/>
+  </data>
+  <data name="Remarks" xml:space="preserve">
+    <value>备注</value>
+    <comment/>
+  </data>
+  <data name="All types" xml:space="preserve">
+    <value>所有类型</value>
+    <comment/>
+  </data>
+  <data name="API documentation" xml:space="preserve">
+    <value>API 文档</value>
+    <comment/>
+  </data>
+  <data name=" Enum" xml:space="preserve">
+    <value> 枚举</value>
+    <comment/>
+  </data>
+  <data name=" Interface" xml:space="preserve">
+    <value> 接口</value>
+    <comment/>
+  </data>
+  <data name=" Struct" xml:space="preserve">
+    <value> 结构体</value>
+    <comment/>
+  </data>
+  <data name=" Class" xml:space="preserve">
+    <value> 类</value>
+    <comment/>
+  </data>
+</root>

--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Globalization;
+using System.Resources;
 
 namespace MdDox
 {
@@ -27,6 +29,16 @@ namespace MdDox
                 prevC = text[i];
             }
             return newText;
+        }
+        public static CultureInfo culture = CultureInfo.CurrentCulture;
+        public static string GetLocalized(this string str)
+        {
+            // 在这里使用 ResourceManager 或其他方式来获取对应语言的本地化字符串
+            // 这里只是一个示例，实际实现取决于你的资源文件结构和加载方式
+            // 假设你的资源文件是以键值对的形式存储的
+            // 这里使用一个假设的 ResourceManager 来获取本地化字符串
+            ResourceManager rm = new ResourceManager("MdDox.Resources.Resources", typeof(Program).Assembly);
+            return rm.GetString(str, culture);
         }
     }
 }

--- a/src/mddox.csproj
+++ b/src/mddox.csproj
@@ -5,7 +5,7 @@
     <Authors>LoxSmoke</Authors>
     <Product>mddox</Product>
     <PackageId>LoxSmoke.mddox</PackageId>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright 2019-2023 LoxSmoke</Copyright>
     <PackageProjectUrl>https://github.com/loxsmoke/mddox</PackageProjectUrl>
@@ -17,8 +17,8 @@
     <ToolCommandName>mddox</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <AssemblyVersion>0.11.1.0</AssemblyVersion>
-    <FileVersion>0.11.1.0</FileVersion>
+    <AssemblyVersion>0.11.2.0</AssemblyVersion>
+    <FileVersion>0.11.2.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile></DocumentationFile>

--- a/src/mddox.csproj
+++ b/src/mddox.csproj
@@ -5,7 +5,7 @@
     <Authors>LoxSmoke</Authors>
     <Product>mddox</Product>
     <PackageId>LoxSmoke.mddox</PackageId>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright 2019-2023 LoxSmoke</Copyright>
     <PackageProjectUrl>https://github.com/loxsmoke/mddox</PackageProjectUrl>
@@ -17,8 +17,8 @@
     <ToolCommandName>mddox</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <AssemblyVersion>0.11.0.0</AssemblyVersion>
-    <FileVersion>0.11.0.0</FileVersion>
+    <AssemblyVersion>0.11.1.0</AssemblyVersion>
+    <FileVersion>0.11.1.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile></DocumentationFile>


### PR DESCRIPTION
Hi loxsmoke, thanks for your wonderful program.

I have added multi-language support by adding `GetLocalized()` function into `StringExtensions Class`. This feature will enable user to generate docs using their own languages. 

Temporarily, I have just added extra Chinese support by adding `Resources/Resources.zh-CN.resx`.  

If we want to add other language support, using French as an example, we just need to copy `Resources/Resources.zh-CN.resx` and rename it to `Resources/Resources.fr-FR.resx`. Then, edit the translation in `Resources/Resources.fr-FR.resx` to French. 

The doc of `DocXml.dll` in Chinese will look like:

# DocXml.dll v.3.6.0.0 API 文档

Created by [mddox](https://github.com/loxsmoke/mddox) on 2024/1/23

# 所有类型

|   |   |   |
|---|---|---|
| [ReflectionExtensions 类](#reflectionextensions-) | [CommonComments 类](#commoncomments-) | [DocXmlReader 类](#docxmlreader-) |
| [EnumComments 类](#enumcomments-) | [EnumValueComment 类](#enumvaluecomment-) | [InheritdocTag 类](#inheritdoctag-) |
| [MethodComments 类](#methodcomments-) | [TypeComments 类](#typecomments-) | [XmlDocId 类](#xmldocid-) |
| [DocXmlReaderExtensions 类](#docxmlreaderextensions-) | [ReflectionSettings 类](#reflectionsettings-) | [TypeCollection 类](#typecollection-) |
| [TypeInformation 类](#typeinformation-) |   |   |
# ReflectionExtensions 类

命名空间：DocXml.Reflection



## 属性

| 名称 | 类型 | 摘要 |
|---|---|---|
| **KnownTypeNames** | Dictionary\<Type, string\> |  |
## 方法

| 名称 | 返回 | 摘要 |
|---|---|---|
| **CleanGenericTypeName(string genericTypeName)** | string |  |
| **CreateKnownTypeNamesDictionary()** | Dictionary\<Type, string\> |  |
| **IsNullable(Type type)** | bool |  |
| **ToNameString(Type type, Func\<Type, string\> typeNameConverter)** | string |  |
| **ToNameString(Type type, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToNameString(Type type, Queue\<string\> tupleFieldNames, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToNameStringWithValueTupleNames(Type type, IList\<string\> tupleNames, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToParametersString(MethodBase methodInfo, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToTypeNameString(ParameterInfo parameterInfo, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToTypeNameString(MethodInfo methodInfo, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToTypeNameString(PropertyInfo propertyInfo, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
| **ToTypeNameString(FieldInfo fieldInfo, Func\<Type, Queue\<string\>, string\> typeNameConverter, bool invokeTypeNameConverterForGenericType)** | string |  |
# CommonComments 类

命名空间：LoxSmoke.DocXml



## 属性

| 名称 | 类型 | 摘要 |
|---|---|---|
| **Summary** | string |  |
| **Remarks** | string |  |
| **Example** | string |  |
| **Inheritdoc** | [InheritdocTag](#inheritdoctag-) |  |
| **FullCommentText** | string |  |
# DocXmlReader 类

命名空间：LoxSmoke.DocXml



## 属性

| 名称 | 类型 | 摘要 |
|---|---|---|
| **UnIndentText** | bool |  |
## 构造函数

| 名称 | 摘要 |
|---|---|
| **DocXmlReader(string fileName, bool unindentText)** |  |
| **DocXmlReader(XPathDocument xPathDocument, bool unindentText)** |  |
| **DocXmlReader(Func\<Assembly, string\> assemblyXmlPathFunction, bool unindentText)** |  |
| **DocXmlReader(IEnumerable\<Assembly\> assemblies, Func\<Assembly, string\> assemblyXmlPathFunction, bool unindentText)** |  |

......
