### PR TITLE
[Feature] Add --strict-headings flag for strictly nested heading hierarchy works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Short format | Long format | Comment
 | -**n**  | --**no-title**            | Do not write the "created by mddox at date" in the markdown file. |
 | -**v**  | --**verbose**             | Print some debug info when generating documentation. It may help troubleshooting some issues such as missing type information of referenced assemblies. |
 | -**l**  | --**language** "language-code"            | Generate output using specified language. Available languages: en-us, zh-cn  |
+|   | --**strict-headings**       | Emit a single top-level H1 (the document title) and nest every other heading beneath it (H2 for "All types" and each type, H3 for Properties/Methods/etc., H4 for individual member details).<br>Without this flag the legacy layout is preserved (multiple H1 headings). |
   
 For best results enable XML documentation build switch in your project and use publish build to get all referenced assemblies in one folder.
 

--- a/src/CommandLineOptions/CommandLineOptions.cs
+++ b/src/CommandLineOptions/CommandLineOptions.cs
@@ -76,5 +76,8 @@ Syntax is the same as for include filters")]
         
         [Option('l', "language", Required = false, HelpText = "Generate output using specified language. Available languages: en-us, zh-cn")]
         public string OutputLanguage { get; set; }
+
+        [Option("strict-headings", Required = false, HelpText = "Emit a single top-level H1 (the document title) and nest every other heading beneath it.\nWithout this flag, \"All types\" and each type title are also written as H1.")]
+        public bool StrictHeadings { get; set; }
     }
 }

--- a/src/DocumentationGenerator.cs
+++ b/src/DocumentationGenerator.cs
@@ -73,7 +73,10 @@ namespace MdDox
         public void WriteDocumentTitle(string titleText)
         {
             if (titleText == null) return;
-            WriteBigTitle(titleText);
+            // The document title is always emitted at H1, even in strict-heading mode where
+            // every other heading is shifted down one level. This keeps the document with a
+            // single, unambiguous top-level header.
+            OutputText.Append(Markdown.Heading(1, titleText));
         }
 
         public void WritedDateLine()
@@ -486,9 +489,16 @@ namespace MdDox
         #endregion
 
         #region Low level write functions
-        public void WriteBigTitle(string title) => OutputText.Append(Markdown.Heading(1, title));
-        public void WriteTitle(string title) => OutputText.Append(Markdown.Heading(2, title));
-        public void WriteSmallTitle(string title) => OutputText.Append(Markdown.Heading(3, title));
+        /// <summary>
+        /// Heading level offset applied to all non-document-title headings when
+        /// <see cref="DocumentationGeneratorOptions.StrictHeadings"/> is enabled. This shifts
+        /// "All types" and per-type titles to H2, member-group sections (Properties, Methods, ...)
+        /// to H3, and method-detail signatures to H4, leaving the document title as the sole H1.
+        /// </summary>
+        private int HeadingOffset => Options.StrictHeadings ? 1 : 0;
+        public void WriteBigTitle(string title) => OutputText.Append(Markdown.Heading(1 + HeadingOffset, title));
+        public void WriteTitle(string title) => OutputText.Append(Markdown.Heading(2 + HeadingOffset, title));
+        public void WriteSmallTitle(string title) => OutputText.Append(Markdown.Heading(3 + HeadingOffset, title));
         public void WriteTableTitle(params string[] tableHeadings) => OutputText.Append(Markdown.TableTitle(tableHeadings));
         public void WriteTableRow(params string[] row) => OutputText.Append(Markdown.TableRow(row));
         public void WriteLine(string text) => OutputText.Append(Markdown.WithNewline(text));

--- a/src/DocumentationGeneratorOptions.cs
+++ b/src/DocumentationGeneratorOptions.cs
@@ -38,5 +38,12 @@ namespace MdDox
         /// Localized strings.
         /// </summary>
         public ILocalizedStrings Strings { get; set; }
+        /// <summary>
+        /// When true, only the document title is emitted as H1 and every other heading is shifted down
+        /// one level, producing a strictly nested heading hierarchy (single H1, H2 for type sections,
+        /// H3 for member groups, H4 for member details). When false (default), the legacy layout is
+        /// preserved (multiple H1 headings for "All types" and each type).
+        /// </summary>
+        public bool StrictHeadings { get; set; }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -182,10 +182,11 @@ namespace MdDox
                     ShowDocumentDateTime = !options.DoNotShowDocumentDateTime,
                     ShowCommandLine = options.ShowCommandLine,
                     AddMsdnLinks = !options.MsdnLinkViewParameter.IsNullOrEmpty(),
-                    MsdnViewParameter = options.MsdnLinkViewParameter.IsNullOrEmpty() || 
+                    MsdnViewParameter = options.MsdnLinkViewParameter.IsNullOrEmpty() ||
                         options.MsdnLinkViewParameter.EqualsIgnoreCase("latest")
                         ? null : options.MsdnLinkViewParameter,
-                    MsdnCultureName = localizedStrings.CultureName.ToLower()
+                    MsdnCultureName = localizedStrings.CultureName.ToLower(),
+                    StrictHeadings = options.StrictHeadings
                 };
 
                 var generator = new DocumentationGenerator(

--- a/test/MddoxTests/CommandLine/CommandLineTests.cs
+++ b/test/MddoxTests/CommandLine/CommandLineTests.cs
@@ -22,6 +22,7 @@ namespace MddoxTests.CommandLine
         [InlineData("assembly", "--msdn", "latest")]
         [InlineData("assembly", "-i", "{assembly} and {version}")]
         [InlineData("assembly", "--title", "{assembly} and {version}")]
+        [InlineData("assembly", "--strict-headings")]
         public void Parse_Valid(params string[] args)
         {
             var result = MdDox.CommandLineOptions.CliProgram.Parse(args);


### PR DESCRIPTION
## Add `--strict-headings` flag for strictly nested markdown heading hierarchy

### Problem

The current output emits multiple H1 (`#`) headings: one for the document title, one for the "All types" section, and one for **every type** documented. This breaks tools and conventions that assume a single top-level H1 per document:

- markdownlint rule MD025 (`single-title`) flags every output
- Doc-site generators (Docusaurus, MkDocs, Hugo, GitBook) often promote the first H1 to the page title and treat additional H1s as errors or render them inconsistently
- Auto-generated tables of contents (e.g. GitHub's reading-pane TOC, doctoc, remark-toc) expect H2+ for navigable sections and skip duplicate H1s
- The structure is not a valid nested outline — readers and accessibility tools can't infer hierarchy

### Solution

Adds an **opt-in** `--strict-headings` CLI flag. When enabled, only the document title is emitted as H1 and every other heading is shifted down one level, producing a strictly nested outline.

Default behavior is unchanged — existing users see no diff in their output unless they pass the new flag.

### Heading-level mapping

| Section | Default (legacy) | `--strict-headings` |
|---|---|---|
| Document title | `#` | `#` |
| "All types" table-of-contents | `#` | `##` |
| Each type title (`Foo Class`, …) | `#` | `##` |
| Properties / Methods / Constructors / Fields / Values | `##` | `###` |
| Individual method/constructor details | `###` | `####` |

### Example

Before (default, unchanged):

~~~markdown
# MyAssembly.dll v1.0.0.0 documentation
# All types
# BasicUser Class
## Properties
## Constructors
### BasicUser(string username, string password)
~~~

After (`--strict-headings`):

~~~markdown
# MyAssembly.dll v1.0.0.0 documentation
## All types
## BasicUser Class
### Properties
### Constructors
#### BasicUser(string username, string password)
~~~

### Implementation notes

- The shift is driven by a single private `HeadingOffset` property on `DocumentationGenerator` (`0` by default, `1` when strict mode is on). `WriteBigTitle` / `WriteTitle` / `WriteSmallTitle` each add the offset.
- `WriteDocumentTitle` now calls `Markdown.Heading(1, …)` directly so the document title stays at H1 regardless of the flag.
- Heading anchor links (`HeadingLink` / `CleanupHeadingAnchor`) are level-independent, so the in-document ToC links continue to resolve correctly in both modes — no anchor changes required.

### Changes

- `src/CommandLineOptions/CommandLineOptions.cs` — new `--strict-headings` option
- `src/DocumentationGeneratorOptions.cs` — new `StrictHeadings` property
- `src/Program.cs` — wires CLI flag → options
- `src/DocumentationGenerator.cs` — heading-level shift via `HeadingOffset`
- `test/MddoxTests/CommandLine/CommandLineTests.cs` — parse test for the new flag
- `README.md` — flag documented in the options table

### Testing

- All existing tests pass.
- Verified by regenerating documentation for a real ~80-type assembly with and without the flag — default output is byte-identical to pre-change output; strict-mode output produces the expected H1 → H2 → H3 → H4 nesting and preserves all anchor links.
